### PR TITLE
Chore/audit support bug fix

### DIFF
--- a/contracts/LiquidPool.sol
+++ b/contracts/LiquidPool.sol
@@ -94,10 +94,15 @@ contract LiquidPool is PoolViews, LiquidEvents {
 
         name = _tokenName;
         symbol = _tokenSymbol;
-        decimals = 18;
+        decimals = DECIMALS_ETH;
 
         chainLinkETH = ROUTER.chainLinkETH();
         poolTokenDecimals = IERC20(_poolToken).decimals();
+
+        require(
+            poolTokenDecimals <= DECIMALS_ETH,
+            "LiquidPool: WEIRD_TOKEN"
+        );
 
         // Calculating lower bound for the pole
         minPole = PRECISION_FACTOR_E18 / 2

--- a/contracts/LiquidRouter.sol
+++ b/contracts/LiquidRouter.sol
@@ -145,7 +145,7 @@ contract LiquidRouter is LiquidTransfer, AccessControl, RouterEvents {
 
         _addWorker(
             _pool,
-            msg.sender
+            multisig
         );
 
         emit LiquidPoolRegistered(

--- a/contracts/PoolHelper.sol
+++ b/contracts/PoolHelper.sol
@@ -778,10 +778,10 @@ contract PoolHelper is PoolBase, PoolShareToken, LiquidTransfer {
 
         uint256 valueETHinUSD = _merkelPriceETH
             * IChainLink(chainLinkETH).latestAnswer()
-            / IChainLink(chainLinkETH).decimals();
+            / 10 ** IChainLink(chainLinkETH).decimals();
 
         return valueETHinUSD
-            * IChainLink(chainLinkFeedAddress).decimals()
+            * 10 ** IChainLink(chainLinkFeedAddress).decimals()
             / IChainLink(chainLinkFeedAddress).latestAnswer()
             / 10 ** (DECIMALS_ETH - poolTokenDecimals);
     }


### PR DESCRIPTION
These changes added to help auditors spot issues and address them as team collaborates with the result: 

- prevention of using odd tokens (with decimals above 18)
- making worker by default (so its easier) 
- conversion for rate between chainlink feeds with different decimals (if any)